### PR TITLE
Changes and updates to message relaying, NV registry key/config separation, new prefixes

### DIFF
--- a/fish.cpp
+++ b/fish.cpp
@@ -288,7 +288,7 @@ public:
 			m_pUser->PutUser(":" + m_pNetwork->GetIRCNick().GetNickMask() + " PRIVMSG " + sTarget + " :" + sMessage, NULL, m_pClient);
 
 			free(cMsg);
-			return HALTCORE;
+			// return HALTCORE;  // We like seeing these on our other clients, so we'll comment this out
 		}
 
 		return CONTINUE;
@@ -309,7 +309,7 @@ public:
 			m_pUser->PutUser(":" + m_pNetwork->GetIRCNick().GetNickMask() + " PRIVMSG " + sTarget + " :\001ACTION " + sMessage + "\001", NULL, m_pClient);
 
 			free(cMsg);
-			return HALTCORE;
+			// return HALTCORE;  // We like seeing these on our other clients, so we'll comment this out
 		}
 
 		return CONTINUE;
@@ -330,7 +330,7 @@ public:
 			m_pUser->PutUser(":" + m_pNetwork->GetIRCNick().GetNickMask() + " NOTICE " + sTarget + " :" + sMessage, NULL, m_pClient);
 
 			free(cMsg);
-			return HALTCORE;
+			// return HALTCORE;  // We like seeing these on our other clients, so we'll comment this out
 		}
 
 		return CONTINUE;
@@ -415,7 +415,8 @@ public:
 				}
 
 				char *cMsg = decrypts((char *)it->second.c_str(), (char *)sMessage.c_str());
-				sMessage = "(e) " + CString(cMsg);
+				// sMessage = "(e) " + CString(cMsg);  // I don't like (e), takes too much space
+				sMessage = CString(cMsg);
 
 				if (mark_broken_block) {
 					sMessage += "  \002&\002";


### PR DESCRIPTION
This change does a few things which I found useful for my installation:
- Relay channel msgs/notices/ACTIONs to other clients connected to this ZNC user/network
- Separate out the NV registry some more, prefixing keys with `key`
- Adding config options, prefixed with `config`, making the encrypted and decrypted (e)/(d) prefixes settable
- Change the default encrypted/decrypted prefixes to blue e or red d, depending on whether the message had to be decrypted or not

**PLEASE NOTE**
This does upgrade your key database, going through and adding `key` to the start of them. It **does not** delete your old prefix-less keys (the old style), so you can still just throw your master branch back on, but you would need to go through afterwards and delete a bunch of useless 'keys'

**I would very strongly recommend making a backup of your database before loading this, to make it simpler to revert back if necessary**
