### PR TITLE
changed CClient type to align with znc-git/1.5

### DIFF
--- a/fish.cpp
+++ b/fish.cpp
@@ -329,7 +329,8 @@ public:
 			free(cMsg);
 
 			// relay to other clients
-			vector<CClient*>& vClients = this->m_pNetwork->GetClients();
+			//vector<CClient*>& vClients = this->m_pNetwork->GetClients();
+			const vector<CClient*>& vClients = this->m_pNetwork->GetClients();
 			for (unsigned int a = 0; a < vClients.size(); a++) {
 				CClient* pClient = vClients[a];
 
@@ -362,7 +363,8 @@ public:
 			free(cMsg);
 
 			// relay to other clients
-			vector<CClient*>& vClients = this->m_pNetwork->GetClients();
+			//vector<CClient*>& vClients = this->m_pNetwork->GetClients();
+			const vector<CClient*>& vClients = this->m_pNetwork->GetClients();
 			for (unsigned int a = 0; a < vClients.size(); a++) {
 				CClient* pClient = vClients[a];
 
@@ -395,7 +397,8 @@ public:
 			free(cMsg);
 
 			// relay to other clients
-			vector<CClient*>& vClients = this->m_pNetwork->GetClients();
+			//vector<CClient*>& vClients = this->m_pNetwork->GetClients();
+			const vector<CClient*>& vClients = this->m_pNetwork->GetClients();
 			for (unsigned int a = 0; a < vClients.size(); a++) {
 				CClient* pClient = vClients[a];
 


### PR DESCRIPTION
When compiling the module against the latest znc cloned from git (znc/znc@78ea60e226e2b0f15b7e8d896ff18a22d0c59e2c) built with gcc-4.8, results in these errors:

> $ znc-buildmod fish.cpp
> Building "fish.so" for ZNC 1.5... fish.cpp: In member function ‘virtual CModule::EModRet CFishMod::OnUserMsg(CString&, CString&)’:
> fish.cpp:332:62: error: invalid initialization of reference of type ‘std::vector<CClient*>&’ from expression of type ‘const std::vector<CClient*>’
>    vector<CClient*>& vClients = this->m_pNetwork->GetClients();
>                                                              ^
> fish.cpp: In member function ‘virtual CModule::EModRet CFishMod::OnUserAction(CString&, CString&)’:
> fish.cpp:366:62: error: invalid initialization of reference of type ‘std::vector<CClient*>&’ from expression of type ‘const std::vector<CClient*>’
>    vector<CClient*>& vClients = this->m_pNetwork->GetClients();
>                                                              ^
> fish.cpp: In member function ‘virtual CModule::EModRet CFishMod::OnUserNotice(CString&, CString&)’:
> fish.cpp:400:62: error: invalid initialization of reference of type ‘std::vector<CClient*>&’ from expression of type ‘const std::vector<CClient*>’
>    vector<CClient*>& vClients = this->m_pNetwork->GetClients();
>                                                              ^
> [ !! ] Error while building "fish.so"

Simple fix, but it fixes all the above errors.
